### PR TITLE
[v1.0.4] Fix can't run dependabot because of Java's version

### DIFF
--- a/.github/gradle/ci-gradle.properties
+++ b/.github/gradle/ci-gradle.properties
@@ -2,3 +2,5 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
+android.nonFinalResIds=false
+android.defaults.buildfeatures.buildconfig=true

--- a/.github/workflows/dependabot_ci.yaml
+++ b/.github/workflows/dependabot_ci.yaml
@@ -38,11 +38,11 @@ jobs:
       - name: Copy gradle properties file
         run: mkdir -p ~/.gradle ; cp .github/gradle/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Setup JDK 11
+      - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
 
       - name: Build the app
         run: ./gradlew assembleDebug
@@ -87,11 +87,11 @@ jobs:
       - name: Copy gradle properties file
         run: mkdir -p ~/.gradle ; cp .github/gradle/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Setup JDK 11
+      - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.0" />
+    <option name="version" value="1.8.0-RC2" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,7 +121,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.0"
+        kotlinCompilerExtensionVersion = "1.3.2"
     }
 
     packaging {
@@ -207,7 +207,7 @@ dependencies {
     implementation("androidx.datastore:datastore-preferences:1.0.0")
 
     // Kotlin reflect
-    implementation("org.jetbrains.kotlin:kotlin-reflect:1.8.0")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:1.7.20")
 
     // Lottie
     implementation("com.airbnb.android:lottie-compose:5.2.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
     id("com.android.application") version "8.1.0-alpha01" apply false
     id("com.android.library") version "8.1.0-alpha01" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.0" apply false
-    id("org.jetbrains.kotlin.jvm") version "1.8.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.7.20" apply false
+    id("org.jetbrains.kotlin.jvm") version "1.7.20" apply false
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin") version "2.0.1" apply false
     id("com.google.dagger.hilt.android") version "2.44.2" apply false
 }


### PR DESCRIPTION
## ✏️ TODO
*(List your doing in your pull request here)*

- Fix dependabot can't run because of Java's version.

## 📘 Libraries
*(List your libraries that you add or modifier in your pull request)*

- Java's version of Zulu: `11` -> `17`

## 🔔 Notes
*(You must provides some information such as how to testing your pull request because this is important for your reviewer to check your pull request)*

- N/A.

## 📷 Screenshots
*(Add some screenshots in here)*

- N/A.
